### PR TITLE
Add support for dry runs

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -64,7 +64,7 @@ func main() {
 		credentialsLocation string
 		targetBranch        string
 		genEncodingMode     string
-		isDryRun						bool
+		isDryRun            bool
 	)
 
 	app.Commands = []cli.Command{
@@ -249,7 +249,7 @@ func main() {
 
 				if isDryRun {
 					fmt.Println("The following release payload would be sent to Github:")
-					j,_ := json.Marshal(r)
+					j, _ := json.Marshal(r)
 					fmt.Println(string(j))
 				} else {
 					// create the release
@@ -415,7 +415,7 @@ func main() {
 
 				if isDryRun {
 					fmt.Println("The following payload would be sent to Github:")
-					j,_ := json.Marshal(r)
+					j, _ := json.Marshal(r)
 					fmt.Println(string(j))
 				} else {
 					deployment, _, errors := gh.Repositories.CreateDeployment(owner, reponame, &r)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -63,6 +64,7 @@ func main() {
 		credentialsLocation string
 		targetBranch        string
 		genEncodingMode     string
+		isDryRun						bool
 	)
 
 	app.Commands = []cli.Command{
@@ -192,6 +194,11 @@ func main() {
 					Usage:       "Branch to base release off from",
 					Destination: &targetBranch,
 				},
+				cli.BoolFlag{
+					Name:        "dry",
+					Usage:       "Is this a dry run or not",
+					Destination: &isDryRun,
+				},
 			},
 			Action: func(c *cli.Context) error {
 				if len(userGithubTag) <= 0 {
@@ -240,45 +247,50 @@ func main() {
 					Draft:           &isDraft,
 				}
 
-				// create the release
-				release, _, e := gh.Repositories.CreateRelease(owner, reponame, &r)
-
-				if e != nil {
-					fmt.Println(e)
-					return cli.NewExitError("Encountered an unexpected error whilst calling the specified Github endpint. Does Travis have permissions to your repository?", 1)
+				if isDryRun {
+					fmt.Println("The following release payload would be sent to Github:")
+					j,_ := json.Marshal(r)
+					fmt.Println(string(j))
 				} else {
-					fmt.Println("Created release " + strconv.Itoa(*release.ID) + " on " + owner + "/" + reponame)
+					// create the release
+					release, _, e := gh.Repositories.CreateRelease(owner, reponame, &r)
+
+					if e != nil {
+						fmt.Println(e)
+						return cli.NewExitError("Encountered an unexpected error whilst calling the specified Github endpint. Does Travis have permissions to your repository?", 1)
+					} else {
+						fmt.Println("Created release " + strconv.Itoa(*release.ID) + " on " + owner + "/" + reponame)
+					}
+
+					// upload the release assets
+					for _, path := range deployablePaths {
+						slices := strings.Split(path, "/")
+						name := slices[len(slices)-1]
+						file, _ := os.Open(path)
+
+						fmt.Println("Uploading " + name + " as a release asset...")
+
+						opt := &github.UploadOptions{Name: name}
+						gh.Repositories.UploadReleaseAsset(owner, reponame, *release.ID, opt, file)
+					}
+
+					fmt.Println("Promoting release from a draft to offical release...")
+
+					// mutability ftw?
+					isDraft = false
+					r2 := github.RepositoryRelease{
+						Draft: &isDraft,
+					}
+
+					_, _, xxx := gh.Repositories.EditRelease(owner, reponame, *release.ID, &r2)
+
+					if xxx != nil {
+						fmt.Println(xxx)
+						fmt.Println("Error encountered, cleaning up release...")
+						gh.Repositories.DeleteRelease(owner, reponame, *release.ID)
+						return cli.NewExitError("Unable to promote this release to an offical release. Please ensure that the no other release references the same tag.", 1)
+					}
 				}
-
-				// upload the release assets
-				for _, path := range deployablePaths {
-					slices := strings.Split(path, "/")
-					name := slices[len(slices)-1]
-					file, _ := os.Open(path)
-
-					fmt.Println("Uploading " + name + " as a release asset...")
-
-					opt := &github.UploadOptions{Name: name}
-					gh.Repositories.UploadReleaseAsset(owner, reponame, *release.ID, opt, file)
-				}
-
-				fmt.Println("Promoting release from a draft to offical release...")
-
-				// mutability ftw?
-				isDraft = false
-				r2 := github.RepositoryRelease{
-					Draft: &isDraft,
-				}
-
-				_, _, xxx := gh.Repositories.EditRelease(owner, reponame, *release.ID, &r2)
-
-				if xxx != nil {
-					fmt.Println(xxx)
-					fmt.Println("Error encountered, cleaning up release...")
-					gh.Repositories.DeleteRelease(owner, reponame, *release.ID)
-					return cli.NewExitError("Unable to promote this release to an offical release. Please ensure that the no other release references the same tag.", 1)
-				}
-
 				return nil
 			},
 		},
@@ -317,6 +329,11 @@ func main() {
 					Name:        "creds, c",
 					Usage:       "GitHub credentials file",
 					Destination: &credentialsLocation,
+				},
+				cli.BoolFlag{
+					Name:        "dry",
+					Usage:       "Is this a dry run or not",
+					Destination: &isDryRun,
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -396,14 +413,17 @@ func main() {
 					Payload: &payload,
 				}
 
-				deployment, _, errors := gh.Repositories.CreateDeployment(owner, reponame, &r)
-
-				if errors != nil {
-					return cli.NewMultiError(errors)
+				if isDryRun {
+					fmt.Println("The following payload would be sent to Github:")
+					j,_ := json.Marshal(r)
+					fmt.Println(string(j))
+				} else {
+					deployment, _, errors := gh.Repositories.CreateDeployment(owner, reponame, &r)
+					if errors != nil {
+						return cli.NewMultiError(errors)
+					}
+					fmt.Println("Created deployment " + strconv.Itoa(*deployment.ID) + " on " + owner + "/" + reponame)
 				}
-
-				fmt.Println("Created deployment " + strconv.Itoa(*deployment.ID) + " on " + owner + "/" + reponame)
-
 				return nil
 			},
 		},

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -120,7 +120,7 @@ func versionFromTag(tagged string) (v *nelson.Version, errs []error) {
 	fe, _ := strconv.ParseInt(arr[1], 10, 32)
 	pa, _ := strconv.ParseInt(arr[2], 10, 32)
 
-	return &nelson.Version{Series: se, Feature: fe, Patch: pa}, nil
+	return &nelson.Version{Series: int32(se), Feature: int32(fe), Patch: int32(pa)}, nil
 }
 
 /* lift the old three-param behavior into the new v2 typed nelson.Deployable */
@@ -133,8 +133,8 @@ func newProtoDeployable(imageUri string, unitName string, tag string) (*nelson.D
 	return &nelson.Deployable{
 		UnitName: unitName,
 		Version:  v,
-		Kind: &nelson.Deployable_Docker{
-			&nelson.Docker{
+		Kind: &nelson.Deployable_Container {
+			&nelson.Container {
 				Image: imageUri,
 			},
 		},

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -133,8 +133,8 @@ func newProtoDeployable(imageUri string, unitName string, tag string) (*nelson.D
 	return &nelson.Deployable{
 		UnitName: unitName,
 		Version:  v,
-		Kind: &nelson.Deployable_Container {
-			&nelson.Container {
+		Kind: &nelson.Deployable_Container{
+			&nelson.Container{
 				Image: imageUri,
 			},
 		},

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: d17f34b131115520fa50873a67e1aa387a0eec2f9a41544d2e788ce12cfd8af9
-updated: 2018-10-11T15:20:32.685732-07:00
+hash: 474cdc8da135becdeda210e91c91743d1f87b07a545863650b4575dd5de59812
+updated: 2018-10-12T08:18:09.351772-07:00
 imports:
 - name: github.com/getnelson/api
-  version: 113cd719a23042e44549bc4c479c25385bc5404d
+  version: 5bdf591afeae6880f49b2026e1975af5a2050ecb
   subpackages:
   - protobuf
 - name: github.com/gogo/googleapis

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,7 +19,7 @@ import:
 - package: gopkg.in/yaml.v2
   version: a5b47d31c556af34a302ce5d659e6fea44d90de0
 - package: github.com/getnelson/api
-  version: 113cd719a23042e44549bc4c479c25385bc5404d
+  version: 5bdf591afeae6880f49b2026e1975af5a2050ecb
   subpackages:
   - protobuf
 - package: github.com/gogo/googleapis


### PR DESCRIPTION
Adds support for `--dry` on the effectual actions so you can see the wire payload prior to it being sent.