### PR TITLE
add environment flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/go-github/github"
-	"gopkg.in/urfave/cli.v1"
+	cli "gopkg.in/urfave/cli.v1"
 
 	nelson "github.com/getnelson/slipway/nelson"
 )
@@ -57,21 +57,23 @@ func main() {
 
 	// switches for the cli
 	var (
-		userDirectory       string
-		userGithubHost      string
-		userGithubTag       string
-		userGithubRepoSlug  string
-		credentialsLocation string
-		targetBranch        string
-		genEncodingMode     string
-		isDryRun            bool
+		userDirectory         string
+		userGithubHost        string
+		userGithubTag         string
+		userGithubRepoSlug    string
+		userGithubDescription string
+		userGithubEnv         string
+		credentialsLocation   string
+		targetBranch          string
+		genEncodingMode       string
+		isDryRun              bool
 	)
 
 	app.Commands = []cli.Command{
 		////////////////////////////// DEPLOYABLE //////////////////////////////////
 		{
 			Name:  "gen",
-			Usage: "generate deployable metdata for units",
+			Usage: "generate deployable metadata for units",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:        "dir, d",
@@ -340,6 +342,18 @@ func main() {
 					Name:  "required-context",
 					Usage: "Required Github contexts that should pass before this deployment can be accepted",
 				},
+				cli.StringFlag{
+					Name:        "description, D",
+					Value:       "",
+					Usage:       "The description to apply to the deployment, for example the deployable's ingress endpoint",
+					Destination: &userGithubDescription,
+				},
+				cli.StringFlag{
+					Name:        "env, e",
+					Value:       "production",
+					Usage:       "GitHub deployment environment to target",
+					Destination: &userGithubEnv,
+				},
 			},
 			Action: func(c *cli.Context) error {
 				if len(userGithubTag) <= 0 {
@@ -418,6 +432,7 @@ func main() {
 					Task:             &task,
 					Payload:          &payload,
 					RequiredContexts: &contexts,
+					Environment:      &userGithubEnv,
 				}
 
 				if isDryRun {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -433,6 +433,7 @@ func main() {
 					Payload:          &payload,
 					RequiredContexts: &contexts,
 					Environment:      &userGithubEnv,
+					Description:      &userGithubDescription,
 				}
 
 				if isDryRun {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/magiconair/properties.v1"
+	properties "gopkg.in/magiconair/properties.v1"
 
 	nelson "github.com/getnelson/slipway/nelson"
 )
@@ -64,7 +64,7 @@ func findDeployableFilesInDir(path string, extension string) ([]string, error) {
 
 		for _, file := range files {
 			filename := file.Name()
-			if (strings.HasSuffix(filename, ".deployable."+extension) || strings.HasSuffix(filename, ".deployable.yaml")) && file.IsDir() == false {
+			if (strings.HasSuffix(filename, ".deployable."+extension) || strings.HasSuffix(filename, ".deployable.yml")) && file.IsDir() == false {
 				desired = append(desired, path+"/"+filename)
 			}
 		}


### PR DESCRIPTION
Added two additional flags to the deployment action:
- Description - whatever people want to display in the UI alongside the deployment
- Environment - this is the environment that bubbles up in the GitHub UI

I also fixed [this reference](https://github.com/getnelson/slipway/pull/20/files#diff-3d26f06e2a3da8bfb583a3f488a3baafR67) while I was in there to match what is produced by the `gen` command.